### PR TITLE
Adding functionality that checks the input YAML file's keys

### DIFF
--- a/include/input.h
+++ b/include/input.h
@@ -13,26 +13,29 @@
 #include "formatted_output.h"
 
 namespace fs = std::filesystem;
-/// \brief Class for parsing input files and arguments
+/// @brief Class for parsing input files and arguments
 
 namespace ccake{
-///@class Input
-///@brief Class for parsing input files and arguments
-///@details The Input class is responsible for parsing the input file and command-line
-///arguments. The constructor receives the command-line arguments, just as the
-///main function does. `argv[1]` is the path to the input file, and `argv[2]` is
-///the path to the results directory.
-///We verify if the input file exists, and if it does, we parse it, initiallizing
-///the settings object. The settings object is created in the heap and stored as
-///a `shared pointer`. You should get ownership of the pointer before destroying
-///the Input object. The settings object can then be shared with the other
-///classes that needs it. We also create the results directory if it does not exist.
+/// @class Input
+/// @brief Class for parsing input files and arguments
+/// @details The Input class is responsible for parsing the input file and command-line
+/// arguments. The constructor receives the command-line arguments, just as the
+/// main function does. `argv[1]` is the path to the input file, and `argv[2]` is
+/// the path to the results directory.
+/// We verify if the input file exists, and if it does, we parse it, initiallizing
+/// the settings object. The settings object is created in the heap and stored as
+/// a `shared pointer`. You should get ownership of the pointer before destroying
+/// the Input object. The settings object can then be shared with the other
+/// classes that needs it. We also create the results directory if it does not exist.
+/// In an effort to ensure simulation fidelity, we also ensure that the parameters provided
+/// in the input file correspond to expected key names when parsing the YAML
 class Input
 {
 private:
   void check_args( int argc, char** argv );
   bool decode_settings(const YAML::Node& node);
   void load_settings_file();
+  YAML::Node validate_input_file(const std::string& input_file);
 
   //Data-members
   fs::path settings_file_path; ///< Path to the settings file


### PR DESCRIPTION
The expected input keys are stored and used to compare against the keys found in the user-provided input YAML file. The Levenshtein distance algorithm is used to determine which of the expected key words is closest to the provided one, and recommended to the user as a correction.