### PR TITLE
Updating files so they will compile with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${PROJECT_BINARY_DIR})
 
 ###############################################################
 # require C++14
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/build_all.sh
+++ b/build_all.sh
@@ -3,8 +3,16 @@
 
 BUILD_DIR=build
 
+# Uncomment to build with g++
 mkdir -p ${BUILD_DIR}
 ( cd ${BUILD_DIR} \
-  && cmake ..     \
+  && cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc ..     \
   && make         \
   && make install )
+
+# Uncomment to build with clang++
+# mkdir -p ${BUILD_DIR}
+# ( cd ${BUILD_DIR} \
+#   && cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..     \
+#   && make         \
+#   && make install )

--- a/include/eos_conformal_diagonal.h
+++ b/include/eos_conformal_diagonal.h
@@ -17,13 +17,13 @@ private:
 
   double c, T0, muB0, muS0, muQ0;
   static constexpr double four_thirds = 4.0/3.0;
-  static constexpr double two_to_two_thirds = pow(2.0, 2.0/3.0);
+  static double two_to_two_thirds;
 
   inline double sgn(double val) { return (0.0 < val) - (val < 0.0); }
 
 public:
   // default constructor/destructor
-  EoS_conformal_diagonal(){std::cout << "In default constructor!\n"; abort();}
+  EoS_conformal_diagonal() = default;
   virtual ~EoS_conformal_diagonal(){}
 
   EoS_conformal_diagonal( const double c_in,
@@ -205,5 +205,6 @@ public:
   }
   
 };
+
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(src OBJECT
 	BSQHydro.cpp
 	ccake.cpp
 	eos.cpp
+    eos_conformal_diagonal.cpp
 	eos_extension.cpp
 	eos_table.cpp
 	formatted_output.cpp

--- a/src/eos_conformal_diagonal.cpp
+++ b/src/eos_conformal_diagonal.cpp
@@ -1,0 +1,4 @@
+
+#include "../include/eos_conformal_diagonal.h"
+
+double EoS_conformal_diagonal::two_to_two_thirds = pow(2.0, 2.0/3.0);


### PR DESCRIPTION
The minimum necessary version of C++ had to be bumped to C++17 to avoid any warning message. Additionally, clang is more opinionated on how and when to use `constexpr`. Static memeber variables can be declared with `constexpr` keyword, however, if the initialization of that variable is from a function that is not `constexpr`, such as `std::pow` (at least until C++26) clang will complain.

So these static initializations need to be moved out of line.

_Note that the compiler tested was clang 14.0_